### PR TITLE
GET posts query param filtering support

### DIFF
--- a/controllers/delete-post-type/test.js
+++ b/controllers/delete-post-type/test.js
@@ -56,14 +56,5 @@ describe('delete post type', () => {
       done()
     })
   })
-
-  after(done => {
-    const queries = [
-      Post.deleteMany({}),
-      PostType.deleteMany({})
-    ]
-
-    Promise.all(queries).then(() => done())
-  })
 })
 

--- a/controllers/delete-post/test.js
+++ b/controllers/delete-post/test.js
@@ -38,11 +38,4 @@ describe('delete post', () => {
       done()
     })
   })
-
-  // remove all posts after all tests are done
-  after(done => {
-    const query = Post.deleteMany({})
-
-    query.then(() => done())
-  })
 })

--- a/controllers/get-posts/index.js
+++ b/controllers/get-posts/index.js
@@ -1,7 +1,21 @@
 const Post = require('../../models/Post')
 
 const getPosts = (req, res) => {
-    const query = Post.find({})
+    const {
+        title,
+        image,
+        thumbnail,
+        id,
+        type
+    } = req.query
+
+    const query = Post.find({
+        ...(title ? { title } : undefined),
+        ...(image ? { images: image } : undefined),
+        ...(thumbnail ? { thumbnailImage: thumbnail } : undefined),
+        ...(type ? { type } : undefined),
+        ...(id ? { _id: id } : undefined),
+    })
     const queryPromise = query.exec()
 
     queryPromise.then(posts =>

--- a/controllers/get-posts/test.js
+++ b/controllers/get-posts/test.js
@@ -1,23 +1,126 @@
 const chai = require('chai')
 const chaiHttp = require('chai-http')
+const mongoose = require('mongoose')
 
 const server = require('../../bin/www')
+const Post = require('../../models/Post')
+const PostType = require('../../models/PostType')
 
 chai.use(chaiHttp)
 const { expect } = chai
 
-const getPostsRequest = () => (
+let postTypeId = ''
+let postId = ''
+const images = ['image-1.jpg', 'image-2.jpg']
+const thumbnailImage = 'some-thumbnail-image.jpg'
+const postTitle = 'test-post-title'
+const stubbedTypeId = mongoose.Types.ObjectId()
+
+const seedDatabase = done => {
+  PostType.create({
+    name: 'test-post-type'
+  }).then(postType => {
+    Post.create([
+      {
+        title: postTitle,
+        type: postType._id,
+        images,
+        thumbnailImage
+      },
+      {
+        title: 'other-post-title',
+        type: stubbedTypeId,
+        images: ['image-3.jpg'],
+        thumbnailImage: 'thumbnail-2.jpg'
+      }
+    ]).then(posts => {
+      postTypeId = postType._id
+      postId = posts[0]._id
+      done()
+    })
+  })
+}
+
+const getPostsRequest = (queryParams = '') => (
   chai.request(server)
-    .get('/api/posts')
+    .get(`/api/posts${queryParams}`)
     .send()
 )
 
 describe('get posts', () => {
+  before(seedDatabase)
+
   it('returns an array of posts', () => {
     getPostsRequest()
       .then(res => {
           expect(res.body).to.have.property('data')
           expect(res.body.data).to.be.instanceof(Array)
       })
+  })
+
+  it('filters by post title', done => {
+    const queryParams = `?title=${postTitle}`
+
+    getPostsRequest(queryParams).then(res => {
+      expect(res.body).to.have.property('data')
+      expect(res.body.data).to.be.instanceof(Array)
+      expect(res.body.data).to.have.length(1)
+      expect(res.body.data[0].title).to.equal(postTitle)
+      done()
+    })
+  })
+
+  it('filters by image', done => {
+    const queryParams = `?image=${images[0]}`
+
+    getPostsRequest(queryParams).then(res => {
+      expect(res.body).to.have.property('data')
+      expect(res.body.data).to.be.instanceof(Array)
+      expect(res.body.data).to.have.length(1)
+      expect(res.body.data[0].images).to.contain(images[0])
+      done()
+    })
+  })
+
+  it('filters by thumbnail', done => {
+    const queryParams = `?thumbnail=${thumbnailImage}`
+
+    getPostsRequest(queryParams).then(res => {
+      expect(res.body).to.have.property('data')
+      expect(res.body.data).to.be.instanceof(Array)
+      expect(res.body.data).to.have.length(1)
+      expect(
+        res.body.data[0].thumbnailImage
+      ).to.equal(thumbnailImage)
+      done()
+    })
+  })
+
+  it('filters by type', done => {
+    const queryParams = `?type=${postTypeId.toString()}`
+
+    getPostsRequest(queryParams).then(res => {
+      expect(res.body).to.have.property('data')
+      expect(res.body.data).to.be.instanceof(Array)
+      expect(res.body.data).to.have.length(1)
+      expect(
+        res.body.data[0].type.toString()
+      ).to.equal(postTypeId.toString())
+      done()
+    })
+  })
+
+  it('filters by ID', done => {
+    const queryParams = `?id=${postId.toString()}`
+
+    getPostsRequest(queryParams).then(res => {
+      expect(res.body).to.have.property('data')
+      expect(res.body.data).to.be.instanceof(Array)
+      expect(res.body.data).to.have.length(1)
+      expect(
+        res.body.data[0]._id.toString()
+        ).to.equal(postId.toString())
+      done()
+    })
   })
 })

--- a/controllers/test.js
+++ b/controllers/test.js
@@ -1,4 +1,6 @@
 const dbConnect = require('../bin/utils/db-connect')
+const Post = require('../models/Post')
+const PostType = require('../models/PostType')
 
 // Connec to DB before any tests run.
 before(done => {
@@ -9,4 +11,14 @@ before(done => {
 })
 
 // Make sure process exits after all tests are done running
-after(() => process.exit(0))
+after(done => {
+  const queries = [
+    Post.deleteMany({}),
+    PostType.deleteMany({})
+  ]
+
+  Promise.all(queries).then(() => {
+    done()
+    process.exit(0)
+  })
+})

--- a/controllers/update-post/test.js
+++ b/controllers/update-post/test.js
@@ -58,11 +58,4 @@ describe('update post', () => {
       done()
     }).catch(console.log)
   })
-
-  after(done => {
-    const queryPostTypes = PostType.deleteMany({})
-    const queryPosts = Post.deleteMany({})
-
-    Promise.all([queryPostTypes, queryPosts]).then(() => done())
-  })
 })

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "cross-env NODE_ENV=test npm run exec-mocha",
     "start-dev": "cross-env NODE_ENV=development node ./bin/www",
+    "start-test-dev": "cross-env NODE_ENV=test node ./bin/www",
     "exec-mocha": "mocha \"./controllers/**/test.js\" \"./utils/**/test.js\" --recursive"
   },
   "author": "Joshua Mora",


### PR DESCRIPTION
Adds filtering support (via query params) for `GET` posts endpoint.
Query param filters added:
- `title`: Allows filtering by title name
- `image`: Find posts that are using the given image path string for `images` property
- `thumbnail`: Find posts that are using the given image path string for `thumbnailImage` property
- `type`: Find posts whose `type` matches the given post type ID
- `id`: Find posts whose `_id` matches the given post ID 