### PR TITLE
Add pagination to posts endpoint

### DIFF
--- a/controllers/get-posts/index.js
+++ b/controllers/get-posts/index.js
@@ -1,4 +1,9 @@
 const Post = require('../../models/Post')
+const {
+    buildDBPagingParams,
+    DEFAULT_PAGE_SIZE,
+    DEFAULT_PAGE
+} = require('../../utils')
 
 const getPosts = (req, res) => {
     const {
@@ -9,17 +14,32 @@ const getPosts = (req, res) => {
         type
     } = req.query
 
+    const page = Number(req.query.page) || DEFAULT_PAGE
+    const pageSize = (
+        Number(req.query.pageSize) || DEFAULT_PAGE_SIZE
+    )
+
+    const { skip, limit } = buildDBPagingParams(page, pageSize)
+
     const query = Post.find({
         ...(title ? { title } : undefined),
         ...(image ? { images: image } : undefined),
         ...(thumbnail ? { thumbnailImage: thumbnail } : undefined),
         ...(type ? { type } : undefined),
         ...(id ? { _id: id } : undefined),
-    })
-    const queryPromise = query.exec()
+    }).skip(skip).limit(limit)
+    const countQuery = Post.countDocuments({})
 
-    queryPromise.then(posts =>
-        res.send({ data: posts })
+    const countQueryPromise = countQuery.exec()
+    const queryPromise = query.exec()
+    Promise.all([
+        queryPromise,
+        countQueryPromise
+    ]).then(([ posts, total ]) =>
+        res.send({
+            data: posts,
+            meta: { page, pageSize, total }
+        })
     ).catch(error =>
         res.status(500).send({
             errors: [{ message: 'An unknown error occurred' }],

--- a/utils/build-db-paging-params/index.js
+++ b/utils/build-db-paging-params/index.js
@@ -1,0 +1,19 @@
+const DEFAULT_PAGE_SIZE = 10
+const DEFAULT_PAGE = 1
+
+const buildDBPagingParams = (
+  page = DEFAULT_PAGE,
+  pageSize = DEFAULT_PAGE_SIZE
+) => {
+  // (1 * 10) = 10 - 10 = 0 skipped for first page
+  // (2 * 10) = 20 - 10 = 10 skipped to get 2nd page, etc.
+  const skip = (page * pageSize) - pageSize
+
+  return { skip, limit: pageSize }
+}
+
+module.exports = {
+  buildDBPagingParams,
+  DEFAULT_PAGE_SIZE,
+  DEFAULT_PAGE
+}

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,5 +1,10 @@
 const Post = require('../models/Post')
 const PostType = require('../models/PostType')
+const {
+  DEFAULT_PAGE_SIZE,
+  DEFAULT_PAGE,
+  buildDBPagingParams
+} = require('./build-db-paging-params')
 
 const writePostToDatabase = (data, _id) => (
   _id ? (
@@ -64,5 +69,8 @@ module.exports = {
   writePostToDatabase,
   extractPostData,
   postTypeValid,
-  validatePostData
+  validatePostData,
+  buildDBPagingParams,
+  DEFAULT_PAGE_SIZE,
+  DEFAULT_PAGE
 }


### PR DESCRIPTION
Adds pagination to posts `GET` endpoint. Utilizes `page` and `pageSize` query params to provide paged results to consumer. Also returns `meta` object in response body which provides `page`, `pageSize`, and `total` values where `total` is number of items in DB.